### PR TITLE
Bulk discount create

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -8,12 +8,12 @@ class BulkDiscountsController < ApplicationController
   # end
 
   def new
-    @bulk_discount = BulkDiscount.new
+    @merchant = Merchant.find(params[:merchant_id])
   end
 
   def create
     @merchant = Merchant.find(params[:merchant_id])
-    @bulk_discount = @merchant.bulk_discounts.create(discount_params)
+    @bulk_discount = @merchant.bulk_discounts.new(discount_params)
     @bulk_discount.save 
     redirect_to merchant_bulk_discounts_path(@merchant.id)
   end

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -3,7 +3,23 @@ class BulkDiscountsController < ApplicationController
     @merchant = Merchant.find(params[:merchant_id])
   end
 
-  def show
-    @bulk_discount = BulkDiscount.find(params[:id])
+  # def show
+  #   @bulk_discount = BulkDiscount.find(params[:id])
+  # end
+
+  def new
+    @bulk_discount = BulkDiscount.new
+  end
+
+  def create
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = @merchant.bulk_discounts.create(discount_params)
+    @bulk_discount.save 
+    redirect_to merchant_bulk_discounts_path(@merchant.id)
+  end
+
+  private
+  def discount_params
+    params.permit(:percentage_discount, :quantity_threshold)
   end
 end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -10,3 +10,7 @@
     </ul>
   </div>
 <% end %>
+
+<div id="new-bulk-discount">
+  <%= link_to "Create A New Bulk Discount", new_merchant_bulk_discount_path(@merchant.id) %>
+</div>

--- a/app/views/bulk_discounts/new.html.erb
+++ b/app/views/bulk_discounts/new.html.erb
@@ -1,3 +1,7 @@
-<%= form_with url: merchant_bulk_discounts_path(@merchant), method: :post, local: true do |f| %>
-
+<%= form_with url: merchant_bulk_discounts_path(@merchant.id), method: :post, local: true do |f| %>
+  <%= f.label :percentage_discount %>
+  <%= f.number_field :percentage_discount %>
+  <%= f.label :quantity_threshold %>
+  <%= f.number_field :quantity_threshold %>
+  <%= f.submit "Submit" %>
 <% end %>

--- a/app/views/bulk_discounts/new.html.erb
+++ b/app/views/bulk_discounts/new.html.erb
@@ -1,0 +1,3 @@
+<%= form_with url: merchant_bulk_discounts_path(@merchant), method: :post, local: true do |f| %>
+
+<% end %>

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -70,4 +70,12 @@ RSpec.describe 'merchants bulk discounts index page', type: :feature do
       expect(page).to have_link("Learn more about this offer!", :href => merchant_bulk_discount_path(@merchant1, @bulk_discount_c))
     end
   end
+
+  it 'shows a link to create a new discount' do
+    expect(page).to have_css("#new-bulk-discount")
+
+    within "#new-bulk-discount" do
+      expect(page).to have_link("Create A New Bulk Discount", :href => new_merchant_bulk_discount_path(@merchant1))
+    end
+  end
 end

--- a/spec/features/bulk_discounts/new_spec.rb
+++ b/spec/features/bulk_discounts/new_spec.rb
@@ -56,11 +56,13 @@ RSpec.describe 'new merchant bulk discount view page', type: :feature do
         expect(page).to have_button("Submit")
       end
 
-      xit 'when I fill in the form with valid data, I am redirected
+      it 'when I fill in the form with valid data, I am redirected
       back to the bulk discount index, and I see my new bulk discount' do 
         fill_in :percentage_discount, with: 50
         fill_in :quantity_threshold, with: 100
-        click_on "Submit", href: merchant_bulk_discounts_path(@merchant1)
+        click_button "Submit"
+        
+        expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
       end
     end
   end

--- a/spec/features/bulk_discounts/new_spec.rb
+++ b/spec/features/bulk_discounts/new_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'new merchant bulk discount view page', type: :feature do
         @transaction6 = Transaction.create!(credit_card_number: 879799, result: 1, invoice_id: @invoice_7.id)
         @transaction7 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_2.id)
 
-        visit new_merchant_bulk_discount_path(@merchant1)
+        visit new_merchant_bulk_discount_path(@merchant1.id)
       end
         
       it 'I see a form to add a new bulk discount' do
@@ -57,8 +57,8 @@ RSpec.describe 'new merchant bulk discount view page', type: :feature do
 
       xit 'when I fill in the form with valid data, I am redirected
       back to the bulk discount index, and I see my new bulk discount' do 
-        fill_in "Percentage Discount", with: 50
-        fill_in "Quantity Threshold", with: 100
+        fill_in :percentage_discount, with: 50
+        fill_in :quantity_threshold, with: 100
         click_on "Submit", :href => merchant_bulk_discounts_path(@merchant1)
       end
     end

--- a/spec/features/bulk_discounts/new_spec.rb
+++ b/spec/features/bulk_discounts/new_spec.rb
@@ -57,7 +57,9 @@ RSpec.describe 'new merchant bulk discount view page', type: :feature do
 
       xit 'when I fill in the form with valid data, I am redirected
       back to the bulk discount index, and I see my new bulk discount' do 
-
+        fill_in "Percentage Discount", with: 50
+        fill_in "Quantity Threshold", with: 100
+        click_on "Submit", :href => merchant_bulk_discounts_path(@merchant1)
       end
     end
   end

--- a/spec/features/bulk_discounts/new_spec.rb
+++ b/spec/features/bulk_discounts/new_spec.rb
@@ -1,5 +1,64 @@
 require 'rails_helper'
 
 RSpec.describe 'new merchant bulk discount view page', type: :feature do
-  
+  describe 'as a merchant' do 
+    describe 'when I am directed to the new merchant bulk discount page' do 
+      before :each do
+        @merchant1 = Merchant.create!(name: 'Hair Care')
+    
+        @bulk_discount_a = BulkDiscount.create!(merchant_id: @merchant1.id, percentage_discount: 20, quantity_threshold: 10)
+        @bulk_discount_b = BulkDiscount.create!(merchant_id: @merchant1.id, percentage_discount: 15, quantity_threshold: 5)
+        @bulk_discount_c = BulkDiscount.create!(merchant_id: @merchant1.id, percentage_discount: 30, quantity_threshold: 20)
+    
+        @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+        @customer_2 = Customer.create!(first_name: 'Cecilia', last_name: 'Jones')
+        @customer_3 = Customer.create!(first_name: 'Mariah', last_name: 'Carrey')
+        @customer_4 = Customer.create!(first_name: 'Leigh Ann', last_name: 'Bron')
+        @customer_5 = Customer.create!(first_name: 'Sylvester', last_name: 'Nader')
+        @customer_6 = Customer.create!(first_name: 'Herber', last_name: 'Kuhn')
+    
+        @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2)
+        @invoice_2 = Invoice.create!(customer_id: @customer_1.id, status: 2)
+        @invoice_3 = Invoice.create!(customer_id: @customer_2.id, status: 2)
+        @invoice_4 = Invoice.create!(customer_id: @customer_3.id, status: 2)
+        @invoice_5 = Invoice.create!(customer_id: @customer_4.id, status: 2)
+        @invoice_6 = Invoice.create!(customer_id: @customer_5.id, status: 2)
+        @invoice_7 = Invoice.create!(customer_id: @customer_6.id, status: 1)
+    
+        @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id)
+        @item_2 = Item.create!(name: "Conditioner", description: "This makes your hair shiny", unit_price: 8, merchant_id: @merchant1.id)
+        @item_3 = Item.create!(name: "Brush", description: "This takes out tangles", unit_price: 5, merchant_id: @merchant1.id)
+        @item_4 = Item.create!(name: "Hair tie", description: "This holds up your hair", unit_price: 1, merchant_id: @merchant1.id)
+    
+        @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 1, unit_price: 10, status: 0)
+        @ii_2 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 1, unit_price: 8, status: 0)
+        @ii_3 = InvoiceItem.create!(invoice_id: @invoice_2.id, item_id: @item_3.id, quantity: 1, unit_price: 5, status: 2)
+        @ii_4 = InvoiceItem.create!(invoice_id: @invoice_3.id, item_id: @item_4.id, quantity: 1, unit_price: 5, status: 1)
+        @ii_5 = InvoiceItem.create!(invoice_id: @invoice_4.id, item_id: @item_4.id, quantity: 1, unit_price: 5, status: 1)
+        @ii_6 = InvoiceItem.create!(invoice_id: @invoice_5.id, item_id: @item_4.id, quantity: 1, unit_price: 5, status: 1)
+        @ii_7 = InvoiceItem.create!(invoice_id: @invoice_6.id, item_id: @item_4.id, quantity: 1, unit_price: 5, status: 1)
+    
+        @transaction1 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_1.id)
+        @transaction2 = Transaction.create!(credit_card_number: 230948, result: 1, invoice_id: @invoice_3.id)
+        @transaction3 = Transaction.create!(credit_card_number: 234092, result: 1, invoice_id: @invoice_4.id)
+        @transaction4 = Transaction.create!(credit_card_number: 230429, result: 1, invoice_id: @invoice_5.id)
+        @transaction5 = Transaction.create!(credit_card_number: 102938, result: 1, invoice_id: @invoice_6.id)
+        @transaction6 = Transaction.create!(credit_card_number: 879799, result: 1, invoice_id: @invoice_7.id)
+        @transaction7 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_2.id)
+
+        visit new_merchant_bulk_discount_path(@merchant1)
+      end
+        
+      it 'I see a form to add a new bulk discount' do
+        expect(page).to have_selector(:css, "form")
+        expect(page).to have_field(:percentage_discount)
+        expect(page).to have_field(:quantity_threshold)
+      end
+
+      xit 'when I fill in the form with valid data, I am redirected
+      back to the bulk discount index, and I see my new bulk discount' do 
+
+      end
+    end
+  end
 end

--- a/spec/features/bulk_discounts/new_spec.rb
+++ b/spec/features/bulk_discounts/new_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe 'new merchant bulk discount view page', type: :feature do
+  
+end

--- a/spec/features/bulk_discounts/new_spec.rb
+++ b/spec/features/bulk_discounts/new_spec.rb
@@ -53,13 +53,14 @@ RSpec.describe 'new merchant bulk discount view page', type: :feature do
         expect(page).to have_selector(:css, "form")
         expect(page).to have_field(:percentage_discount)
         expect(page).to have_field(:quantity_threshold)
+        expect(page).to have_button("Submit")
       end
 
       xit 'when I fill in the form with valid data, I am redirected
       back to the bulk discount index, and I see my new bulk discount' do 
         fill_in :percentage_discount, with: 50
         fill_in :quantity_threshold, with: 100
-        click_on "Submit", :href => merchant_bulk_discounts_path(@merchant1)
+        click_on "Submit", href: merchant_bulk_discounts_path(@merchant1)
       end
     end
   end


### PR DESCRIPTION
- adds a link to the merchants bulk discount index page to add a new discount
- redirects to a form that gives the merchant the ability to create a new bulk discount
- the form is able to be filled out, and when the merchant clicks submit, they are redirected back to the merchants bulk discount index page where they see a new bulk discount listed