### PR TITLE
Bulk discount delete

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -18,6 +18,13 @@ class BulkDiscountsController < ApplicationController
     redirect_to merchant_bulk_discounts_path(@merchant.id)
   end
 
+  def destroy
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = BulkDiscount.find(params[:id])
+    @bulk_discount.destroy!
+    redirect_to merchant_bulk_discounts_path(@merchant.id) 
+  end
+
   private
   def discount_params
     params.permit(:percentage_discount, :quantity_threshold)

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -6,6 +6,7 @@
       <li>Save <%= discount.percentage_discount %>% when you purchase <%= discount.quantity_threshold %> of the same item.</li>
         <ul>
           <li><%= link_to "Learn more about this offer!", merchant_bulk_discount_path(@merchant.id, discount.id) %></li>
+          <li><%= link_to "Delete This Offer", merchant_bulk_discount_path(@merchant.id, discount.id), method: :delete %></li>
         </ul>
     </ul>
   </div>

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -78,4 +78,37 @@ RSpec.describe 'merchants bulk discounts index page', type: :feature do
       expect(page).to have_link("Create A New Bulk Discount", :href => new_merchant_bulk_discount_path(@merchant1))
     end
   end
+
+  it 'each bulk discount has a link to delete that discount. when the merchant
+  clicks this link, it redirects back to the bulk discount index page and that
+  discount is not longer listed' do
+    within "#merchant-discount#{@bulk_discount_a.id}" do
+      expect(page).to have_link("Delete This Offer", :href => merchant_bulk_discounts_path(@merchant1))
+    end
+
+    within "#merchant-discount#{@bulk_discount_b.id}" do
+      expect(page).to have_link("Delete This Offer", :href => merchant_bulk_discounts_path(@merchant1))
+    end
+
+    within "#merchant-discount#{@bulk_discount_c.id}" do
+      expect(page).to have_link("Delete This Offer", :href => merchant_bulk_discounts_path(@merchant1))
+    end
+
+    within "#merchant-discount#{@bulk_discount_b.id}" do
+      click_link "Delete This Offer"
+    end
+
+    expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
+    expect(page).to_not have_css("#merchant-discount#{@bulk_discount_b.id}")
+    expect(page).to have_css("#merchant-discount#{@bulk_discount_a.id}")
+    expect(page).to have_css("#merchant-discount#{@bulk_discount_c.id}")
+    
+    within "#merchant-discount#{@bulk_discount_c.id}" do
+      click_link "Delete This Offer"
+    end
+
+    expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
+    expect(page).to_not have_css("#merchant-discount#{@bulk_discount_c.id}")
+    expect(page).to have_css("#merchant-discount#{@bulk_discount_a.id}")
+  end
 end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -83,15 +83,15 @@ RSpec.describe 'merchants bulk discounts index page', type: :feature do
   clicks this link, it redirects back to the bulk discount index page and that
   discount is not longer listed' do
     within "#merchant-discount#{@bulk_discount_a.id}" do
-      expect(page).to have_link("Delete This Offer", :href => merchant_bulk_discounts_path(@merchant1))
+      expect(page).to have_link("Delete This Offer")
     end
 
     within "#merchant-discount#{@bulk_discount_b.id}" do
-      expect(page).to have_link("Delete This Offer", :href => merchant_bulk_discounts_path(@merchant1))
+      expect(page).to have_link("Delete This Offer")
     end
 
     within "#merchant-discount#{@bulk_discount_c.id}" do
-      expect(page).to have_link("Delete This Offer", :href => merchant_bulk_discounts_path(@merchant1))
+      expect(page).to have_link("Delete This Offer")
     end
 
     within "#merchant-discount#{@bulk_discount_b.id}" do


### PR DESCRIPTION
- adds a link to the merchants bulk discount index to delete a bulk discount
- when the user clicks the link, they are directed back to the merchant bulk discount page where they no longer see the deleted bulk discount