### PR TITLE
Bulk discount edit

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -26,6 +26,17 @@ class BulkDiscountsController < ApplicationController
     redirect_to merchant_bulk_discounts_path(@merchant.id) 
   end
 
+  def edit 
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = BulkDiscount.find(params[:id])
+  end
+
+  def update
+    @bulk_discount = BulkDiscount.find(params[:id])
+    @bulk_discount.update(discount_params)
+    redirect_to merchant_bulk_discount_path(@bulk_discount.merchant, @bulk_discount)
+  end
+
   private
   def discount_params
     params.permit(:percentage_discount, :quantity_threshold)

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,6 +1,6 @@
 <h2>Update <%= @bulk_discount.percentage_discount %>% Bulk Discount:</h2>
 
-<%= form_with url: merchant_bulk_discounts_path(merchant_bulk_discount_path(@merchant.id, @bulk_discount.id)), method: :patch, local: true do |f| %>
+<%= form_with url: merchant_bulk_discount_path(@merchant, @bulk_discount), method: :patch, local: true do |f| %>
   <%= f.label :percentage_discount %>
   <%= f.number_field :percentage_discount, value: @bulk_discount.percentage_discount %>
   <%= f.label :quantity_threshold %>

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,9 @@
+<h2>Update <%= @bulk_discount.percentage_discount %>% Bulk Discount:</h2>
+
+<%= form_with url: merchant_bulk_discounts_path(merchant_bulk_discount_path(@merchant.id, @bulk_discount.id)), method: :patch, local: true do |f| %>
+  <%= f.label :percentage_discount %>
+  <%= f.number_field :percentage_discount, value: @bulk_discount.percentage_discount %>
+  <%= f.label :quantity_threshold %>
+  <%= f.number_field :quantity_threshold, value: @bulk_discount.quantity_threshold %>
+  <%= f.submit "Submit" %>
+<% end %>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -10,3 +10,5 @@
   <li>If the quantity of an item ordered meets or exceeds the quantity threshold, then the percentage discount should apply to that item only. Other items that did not meet the quantity threshold will not be affected.</li>
   <li>The quantities of multiple unique items ordered cannot be added together to meet the quantity thresholds.</li>
 </ul>
+
+<p><%= link_to "Edit This Bulk Discount", edit_merchant_bulk_discount_path(@merchant, @bulk_discount) %></p>

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -4,13 +4,16 @@ RSpec.describe 'merchant bulk discount edit page', type: :feature do
   describe 'as a merchant' do
     describe 'when I visit edit_merchant_bulk_discount_path' do
       it 'has a form with the discounts current attributes pre-populated in the form' do
-
+        expect(page).to have_selector(:css, "form")
+        expect(page).to have_field(:percentage_discount, with: )
+        expect(page).to have_field(:quantity_threshold, with: )
+        expect(page).to have_button("Submit")
       end
 
       it 'when I change any/all of the information and click submit, I am redirected
       back to the bulk discounts show page and I see that the discounts attributes 
       have been updated' do
-        
+
       end
     end
   end

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -3,17 +3,70 @@ require 'rails_helper'
 RSpec.describe 'merchant bulk discount edit page', type: :feature do
   describe 'as a merchant' do
     describe 'when I visit edit_merchant_bulk_discount_path' do
+      before :each do
+        @merchant1 = Merchant.create!(name: 'Hair Care')
+    
+        @bulk_discount_a = BulkDiscount.create!(merchant_id: @merchant1.id, percentage_discount: 20, quantity_threshold: 10)
+        @bulk_discount_b = BulkDiscount.create!(merchant_id: @merchant1.id, percentage_discount: 15, quantity_threshold: 5)
+        @bulk_discount_c = BulkDiscount.create!(merchant_id: @merchant1.id, percentage_discount: 30, quantity_threshold: 20)
+    
+        @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+        @customer_2 = Customer.create!(first_name: 'Cecilia', last_name: 'Jones')
+        @customer_3 = Customer.create!(first_name: 'Mariah', last_name: 'Carrey')
+        @customer_4 = Customer.create!(first_name: 'Leigh Ann', last_name: 'Bron')
+        @customer_5 = Customer.create!(first_name: 'Sylvester', last_name: 'Nader')
+        @customer_6 = Customer.create!(first_name: 'Herber', last_name: 'Kuhn')
+    
+        @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2)
+        @invoice_2 = Invoice.create!(customer_id: @customer_1.id, status: 2)
+        @invoice_3 = Invoice.create!(customer_id: @customer_2.id, status: 2)
+        @invoice_4 = Invoice.create!(customer_id: @customer_3.id, status: 2)
+        @invoice_5 = Invoice.create!(customer_id: @customer_4.id, status: 2)
+        @invoice_6 = Invoice.create!(customer_id: @customer_5.id, status: 2)
+        @invoice_7 = Invoice.create!(customer_id: @customer_6.id, status: 1)
+    
+        @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id)
+        @item_2 = Item.create!(name: "Conditioner", description: "This makes your hair shiny", unit_price: 8, merchant_id: @merchant1.id)
+        @item_3 = Item.create!(name: "Brush", description: "This takes out tangles", unit_price: 5, merchant_id: @merchant1.id)
+        @item_4 = Item.create!(name: "Hair tie", description: "This holds up your hair", unit_price: 1, merchant_id: @merchant1.id)
+    
+        @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 1, unit_price: 10, status: 0)
+        @ii_2 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 1, unit_price: 8, status: 0)
+        @ii_3 = InvoiceItem.create!(invoice_id: @invoice_2.id, item_id: @item_3.id, quantity: 1, unit_price: 5, status: 2)
+        @ii_4 = InvoiceItem.create!(invoice_id: @invoice_3.id, item_id: @item_4.id, quantity: 1, unit_price: 5, status: 1)
+        @ii_5 = InvoiceItem.create!(invoice_id: @invoice_4.id, item_id: @item_4.id, quantity: 1, unit_price: 5, status: 1)
+        @ii_6 = InvoiceItem.create!(invoice_id: @invoice_5.id, item_id: @item_4.id, quantity: 1, unit_price: 5, status: 1)
+        @ii_7 = InvoiceItem.create!(invoice_id: @invoice_6.id, item_id: @item_4.id, quantity: 1, unit_price: 5, status: 1)
+    
+        @transaction1 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_1.id)
+        @transaction2 = Transaction.create!(credit_card_number: 230948, result: 1, invoice_id: @invoice_3.id)
+        @transaction3 = Transaction.create!(credit_card_number: 234092, result: 1, invoice_id: @invoice_4.id)
+        @transaction4 = Transaction.create!(credit_card_number: 230429, result: 1, invoice_id: @invoice_5.id)
+        @transaction5 = Transaction.create!(credit_card_number: 102938, result: 1, invoice_id: @invoice_6.id)
+        @transaction6 = Transaction.create!(credit_card_number: 879799, result: 1, invoice_id: @invoice_7.id)
+        @transaction7 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_2.id)
+    
+        visit edit_merchant_bulk_discount_path(@merchant1, @bulk_discount_a)
+      end
+
       it 'has a form with the discounts current attributes pre-populated in the form' do
         expect(page).to have_selector(:css, "form")
-        expect(page).to have_field(:percentage_discount, with: )
-        expect(page).to have_field(:quantity_threshold, with: )
+        expect(page).to have_field(:percentage_discount, with: 20)
+        expect(page).to have_field(:quantity_threshold, with: 10)
         expect(page).to have_button("Submit")
       end
 
       it 'when I change any/all of the information and click submit, I am redirected
       back to the bulk discounts show page and I see that the discounts attributes 
       have been updated' do
+        fill_in :percentage_discount, with: 25
+        fill_in :quantity_threshold, with: 15
+        click_button "Submit"
 
+        expect(current_path).to eq(merchant_bulk_discount_path(@merchant1, @bulk_discount_a))
+
+        expect(page).to have_content("Percentage Discount: 25%")
+        expect(page).to have_content("Quantity Threshold: 15")
       end
     end
   end

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'merchant bulk discount edit page', type: :feature do
+  describe 'as a merchant' do
+    describe 'when I visit edit_merchant_bulk_discount_path' do
+      it 'has a form with the discounts current attributes pre-populated in the form' do
+
+      end
+
+      it 'when I change any/all of the information and click submit, I am redirected
+      back to the bulk discounts show page and I see that the discounts attributes 
+      have been updated' do
+        
+      end
+    end
+  end
+end

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -59,8 +59,12 @@ RSpec.describe 'merchants bulk discount show page', type: :feature do
       end
 
       it 'has a link to edit the bulk discount. when I click this link, I am 
-      taken to a new page with a form to edit the discount.' do
-        
+      taken to a new page to edit the discount.' do
+        expect(page).to have_link("Edit This Bulk Discount", :href => edit_merchant_bulk_discount_path(@merchant1, @bulk_discount_a))
+
+        click_link("Edit This Bulk Discount")
+
+        expect(current_path).to eq(edit_merchant_bulk_discount_path(@merchant1, @bulk_discount_a))
       end
     end
   end

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -57,6 +57,11 @@ RSpec.describe 'merchants bulk discount show page', type: :feature do
         expect(page).to have_content("If the quantity of an item ordered meets or exceeds the quantity threshold, then the percentage discount should apply to that item only. Other items that did not meet the quantity threshold will not be affected.")
         expect(page).to have_content("The quantities of multiple unique items ordered cannot be added together to meet the quantity thresholds.")
       end
+
+      it 'has a link to edit the bulk discount. when I click this link, I am 
+      taken to a new page with a form to edit the discount.' do
+        
+      end
     end
   end
 end


### PR DESCRIPTION
- adds a link to edit bulk discount on bulk discount show page
- redirects to bulk discount edit page
- edit page has a form that auto fills with the current values of the bulk discount
- you can change the values and click submit
- redirects back to bulk discount show page with updated discount information